### PR TITLE
handle invalid urls

### DIFF
--- a/lib/princeton_marc.rb
+++ b/lib/princeton_marc.rb
@@ -208,11 +208,12 @@ end
 # anchor text ($y, $3, hostname), and additional labels ($z) (array value)
 def electronic_access_links record
   links = {}
-  Traject::MarcExtractor.cached('856u').collect_matching_lines(record) do |field, spec, extractor|
-    url = extractor.collect_subfields(field, spec).first
+  Traject::MarcExtractor.cached('856').collect_matching_lines(record) do |field, spec, extractor|
     anchor_text = false
     z_label = false
+    url = false
     field.subfields.each do |s_field|
+      url = s_field.value if s_field.code == 'u'
       z_label = s_field.value if s_field.code == 'z'
       if s_field.code == 'y' || s_field.code == '3'
         if anchor_text
@@ -222,9 +223,11 @@ def electronic_access_links record
         end
       end
     end
-    anchor_text = URI.parse(url).host unless anchor_text
-    links[url] = [anchor_text] # anchor text is first element
-    links[url] << z_label if z_label # optional 2nd element if z
+    if url and (URI.parse(url) rescue nil)
+      anchor_text = URI.parse(url).host unless anchor_text
+      links[url] = [anchor_text] # anchor text is first element
+      links[url] << z_label if z_label # optional 2nd element if z
+    end
   end
   links
 end

--- a/spec/lib/princeton_marc_spec.rb
+++ b/spec/lib/princeton_marc_spec.rb
@@ -11,11 +11,13 @@ describe 'From princeton_marc.rb' do
       @url2 = 'yahoo.com'
       @url3 = 'princeton.edu'
       @long_url = 'http://aol.com/234/asdf/24tdsfsdjf'
+      @invalid_url = 'mail.usa not link'
       @l856 = {"856"=>{"ind1"=>" ", "ind2"=>" ", "subfields"=>[{"u"=>@url1}, {"y"=>"GOOGLE!"}, {"z"=>"label"} ]}}
       @l856_1 = {"856"=>{"ind1"=>" ", "ind2"=>" ", "subfields"=>[{"u"=>@url2}, {"3"=>"Table of contents"} ]}}
       @l856_2 = {"856"=>{"ind1"=>" ", "ind2"=>" ", "subfields"=>[{"u"=>@long_url}]}}
       @l856_3 = {"856"=>{"ind1"=>" ", "ind2"=>" ", "subfields"=>[{"u"=>@url3}, {"y"=>"text 1"}, {"3"=>"text 2"}]}}
-      @sample_marc = MARC::Record.new_from_hash({ 'fields' => [@l856, @l856_1, @l856_2, @l856_3] })
+      @l856_4 = {"856"=>{"ind1"=>" ", "ind2"=>" ", "subfields"=>[{"u"=>@invalid_url}]}}
+      @sample_marc = MARC::Record.new_from_hash({ 'fields' => [@l856, @l856_1, @l856_2, @l856_3, @l856_4] })
       @links = electronic_access_links(@sample_marc)
     end
 
@@ -24,6 +26,10 @@ describe 'From princeton_marc.rb' do
       expect(@links[@url2]).to eq(["Table of contents"])
       expect(@links[@url3]).to eq(["text 1: text 2"])
       expect(@links[@long_url]).to eq(["aol.com"])
+    end
+
+    it 'skips invalid urls' do
+      expect(@links).not_to include(@invalid_url)
     end
   end
 


### PR DESCRIPTION
The URI parser raises an exception if the url is invalid. This commit prevents invalid urls from being included.
