### PR TITLE
Add voyager location code to key holdings_1display.

### DIFF
--- a/lib/traject_config.rb
+++ b/lib/traject_config.rb
@@ -800,6 +800,7 @@ to_field 'holdings_1display' do |record, accumulator|
     field.subfields.each do |s_field|
       if s_field.code == 'b'
         holding['location'] = TranslationMap.new("locations", :default => "__passthrough__")[s_field.value]
+        holding['location_code'] = s_field.value
       elsif /[ckhij]/.match(s_field.code)
         holding['call_number'] ||= '' 
         holding['call_number'] += s_field.value


### PR DESCRIPTION
This adds the voyager location code as a key available in this field in the solr document. It is useful to have this inline with the holding location name and call number so JS events can be overlaid upon any HTML generated from this list. 
