### PR TITLE
exclude online and invalid codes from library facet

### DIFF
--- a/spec/fixtures/sample1.mrx
+++ b/spec/fixtures/sample1.mrx
@@ -52,7 +52,7 @@
       <marc:subfield code="a">Bibliography: p. 202-203.</marc:subfield>
     </marc:datafield>
     <marc:datafield tag="852" ind1="8" ind2="0">
-      <marc:subfield code="b">rcppf</marc:subfield>
+      <marc:subfield code="b">invalidcode</marc:subfield>
       <marc:subfield code="t">1</marc:subfield>
       <marc:subfield code="h">MICROFILM 03732</marc:subfield>
       <marc:subfield code="x">tr fr flm</marc:subfield>

--- a/spec/lib/config_spec.rb
+++ b/spec/lib/config_spec.rb
@@ -67,21 +67,21 @@ describe 'From traject_config.rb' do
     end
   end
   describe 'access_facet' do
-    it 'value is at the library for all non-online holding locations' do
+    it 'value is in the library for all non-online holding locations' do
       expect(@sample3['location_code_s'][0]).to eq 'scidoc' # Lewis Library
-      expect(@sample3['access_facet']).to include 'At the Library'
+      expect(@sample3['access_facet']).to include 'In the Library'
       expect(@sample3['access_facet']).not_to include 'Online'
     end
     it 'value is online for elf holding locations' do
       expect(@online['location_code_s'][0]).to eq 'elf1'
       expect(@online['access_facet']).to include 'Online'
-      expect(@online['access_facet']).not_to include 'At the Library'
+      expect(@online['access_facet']).not_to include 'In the Library'
     end
-    it 'value can be both at the library and online when there are multiple holdings' do
+    it 'value can be both in the library and online when there are multiple holdings' do
       expect(@online_at_library['location_code_s']).to include 'elf1'
       expect(@online_at_library['location_code_s']).to include 'rcpph'
       expect(@online_at_library['access_facet']).to include 'Online'
-      expect(@online_at_library['access_facet']).to include 'At the Library'
+      expect(@online_at_library['access_facet']).to include 'In the Library'
     end
   end
   describe 'holdings_1display' do
@@ -114,6 +114,17 @@ describe 'From traject_config.rb' do
     it 'holding 856s are excluded from electronic_access_1display' do
       electronic_access = JSON.parse(@solr_hash['electronic_access_1display'].first)
       expect(electronic_access).not_to include('holding_record_856s')
+    end
+  end
+  describe 'excluding locations from library facet' do
+    it 'when location is online' do
+      expect(@online['location_code_s']).to include 'elf1'
+      expect(@online['location']).to be_nil
+    end
+
+    it 'when location codes that do not map to labels' do
+      expect(@sample1['location_code_s']).to include 'invalidcode'
+      expect(@sample1['location']).to be_nil
     end
   end
 end


### PR DESCRIPTION
Online locations are no longer included in the library facet (they are included in the access facet).
Location codes that don't map to a label in the location service are excluded from the library facet and logged.
Changed "At the Library" to "In the Library"
