### PR TITLE
logs records with multiple 245s, uses first 245 in single-valued title_display field

### DIFF
--- a/lib/traject_config.rb
+++ b/lib/traject_config.rb
@@ -930,4 +930,10 @@ each_record do |record, context|
       logger.error "#{context.output_hash['id'].first} - Invalid Location Code: #{l}" unless mapped_codes[l]
     end
   end
+  if context.output_hash['title_display']
+    if context.output_hash['title_display'].length > 1
+      logger.error "#{context.output_hash['id'].first} - Multiple titles"
+      context.output_hash['title_display'] = context.output_hash['title_display'].slice(0,1)
+    end
+  end
 end

--- a/spec/fixtures/sample3.mrx
+++ b/spec/fixtures/sample3.mrx
@@ -25,6 +25,9 @@
       <marc:subfield code="a">New accessions list /</marc:subfield>
       <marc:subfield code="c">World Data Center A for Glaciology [Snow and Ice].</marc:subfield>
     </marc:datafield>
+    <marc:datafield tag="245" ind1="1" ind2="0">
+      <marc:subfield code="a">Should Not Be Here</marc:subfield>
+    </marc:datafield>
     <marc:datafield tag="260" ind1=" " ind2=" ">
       <marc:subfield code="a">Boulder, Col. :</marc:subfield>
       <marc:subfield code="b">The Center,</marc:subfield>

--- a/spec/lib/config_spec.rb
+++ b/spec/lib/config_spec.rb
@@ -149,4 +149,9 @@ describe 'From traject_config.rb' do
       expect(other_title_hash['English title also known as']).to include 'Dad for rent'
     end
   end
+  describe 'multiple 245s' do
+    it 'only uses first 245 in single-valued title_display field' do
+      expect(@sample3['title_display'].length).to eq 1
+    end
+  end
 end


### PR DESCRIPTION
The title_display field (which pulls from MARC 245) was reconfigured to be a single_valued field (based on the [MARC standard](http://www.loc.gov/marc/bibliographic/bd245.html) 245 is non-repeating). Allows records that have multiple 245s to still be indexed into Solr. Takes first 245 value and logs the bib id if there are multiple 245s present in the MARC. @joycebcat currently there are [90 records](https://www.dropbox.com/s/9bks71hd5ktdi65/bibs_multiple_245.txt?dl=0) with multiple 245s.
