### PR TITLE
link bib ids in 776w/787w

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: ruby
+sudo: false
 rvm:
   - jruby-9.0.4.0 # JRuby most recent
 # uncomment this line if your project needs to run something other than `rake`:

--- a/lib/princeton_marc.rb
+++ b/lib/princeton_marc.rb
@@ -130,14 +130,20 @@ end
 # ISBN: 020a, 020z, 776z
 # ISSN: 022a, 022l, 022y, 022z, 776x
 # OCLC: 035a, 776w, 787w
+# BIB: 776w, 787w (adds BIB prefix so Blacklight can detect whether to search id field)
 def other_versions record
   linked_nums = []
   Traject::MarcExtractor.cached('020az:022alyz:035a:776wxz:787w').collect_matching_lines(record) do |field, spec, extractor|
     field.subfields.each do |s_field|
       linked_nums << StdNum::ISBN.normalize(s_field.value) if (field.tag == "020") or (field.tag == "776" and s_field.code == 'z')
       linked_nums << StdNum::ISSN.normalize(s_field.value) if (field.tag == "022") or (field.tag == "776" and s_field.code == 'x')
-      if (field.tag == "035") or (field.tag == "776" and s_field.code == 'w') or (field.tag == "787" and s_field.code == 'w')
-        linked_nums << oclc_normalize(s_field.value, prefix: true) if s_field.value.start_with?('(OCoLC)')
+      linked_nums << oclc_normalize(s_field.value, prefix: true) if s_field.value.start_with?('(OCoLC)') and (field.tag == "035")
+      if (field.tag == "776" and s_field.code == 'w') or (field.tag == "787" and s_field.code == 'w')
+        linked_nums << oclc_normalize(s_field.value, prefix: true) if s_field.value.include?('(OCoLC)')
+        linked_nums << "BIB" + strip_non_numeric(s_field.value) unless s_field.value.include?('(')
+        if s_field.value.include?('(') and !s_field.value.start_with?('(')
+          logger.error "#{record['001']} - linked field formatting: #{s_field.value}"
+        end
       end
     end
   end
@@ -276,8 +282,12 @@ def process_subject_topic_facet record
   subjects.flatten
 end
 
+def strip_non_numeric num_str
+  num_str.gsub(/\D/, '').to_i.to_s
+end
+
 def oclc_normalize oclc, opts = {prefix: false}
-  oclc_num = oclc.gsub(/\D/, '').to_i.to_s
+  oclc_num = strip_non_numeric(oclc)
   if opts[:prefix] == true
     case oclc_num.length
     when 1..8

--- a/spec/lib/princeton_marc_spec.rb
+++ b/spec/lib/princeton_marc_spec.rb
@@ -101,8 +101,10 @@ describe 'From princeton_marc.rb' do
 
   describe 'other_versions function' do
     before(:all) do
-      @non_oclc_num = '12345678'
-      @non_oclc_776w = {"776"=>{"ind1"=>"", "ind2"=>" ", "subfields"=>[{"w"=>@non_oclc_num}]}}
+      @bib = '12345678'
+      @bib_776w = {"776"=>{"ind1"=>"", "ind2"=>" ", "subfields"=>[{"w"=>@bib}]}}
+      @non_oclc_non_bib = '(DLC)12345678'
+      @non_oclc_non_bib_776w = {"776"=>{"ind1"=>"", "ind2"=>" ", "subfields"=>[{"w"=>@non_oclc_non_bib}]}}
       @oclc_num = '(OCoLC)on9990014350'
       @oclc_776w = {"776"=>{"ind1"=>"", "ind2"=>" ", "subfields"=>[{"w"=>@oclc_num}]}}
       @oclc_num2 = '(OCoLC)on9990014351'
@@ -119,7 +121,7 @@ describe 'From princeton_marc.rb' do
       @isbn_num2 = 'ISBN: 978-0-306-40615-7'
       @isbn_num2_10d = '0-306-40615-2'
       @isbn_020 = {"020"=>{"ind1"=>"", "ind2"=>" ", "subfields"=>[{"a"=>@isbn_num2}, {"z"=>@isbn_num2_10d}]}}
-      @sample_marc = MARC::Record.new_from_hash({ 'fields' => [@non_oclc_776w, @oclc_776w, @oclc_787w, @oclc_035a, @issn_022, @issn_776x, @isbn_776z, @isbn_020] })
+      @sample_marc = MARC::Record.new_from_hash({ 'fields' => [@bib_776w, @non_oclc_non_bib_776w, @oclc_776w, @oclc_787w, @oclc_035a, @issn_022, @issn_776x, @isbn_776z, @isbn_020] })
       @linked_nums = other_versions(@sample_marc)
     end
 
@@ -127,6 +129,7 @@ describe 'From princeton_marc.rb' do
       expect(@linked_nums).to include(oclc_normalize(@oclc_num, prefix: true))
       expect(@linked_nums).to include(oclc_normalize(@oclc_num2, prefix: true))
       expect(@linked_nums).to include(oclc_normalize(@oclc_num4, prefix: true))
+      expect(@linked_nums).to include('BIB' + strip_non_numeric(@bib))
       expect(@linked_nums).to include(StdNum::ISSN.normalize(@issn_num))
       expect(@linked_nums).to include(StdNum::ISSN.normalize(@issn_num2))
       expect(@linked_nums).to include(StdNum::ISBN.normalize(@isbn_num))
@@ -144,8 +147,8 @@ describe 'From princeton_marc.rb' do
       expect(@linked_nums).not_to include(oclc_normalize(@oclc_num3, prefix: true))
     end
 
-    it 'excludes non oclc in expected oclc subfield' do
-      expect(@linked_nums).not_to include(oclc_normalize(@non_oclc_num, prefix: true))
+    it 'excludes non oclc/non bib in expected oclc/bib subfield' do
+      expect(@linked_nums).not_to include(oclc_normalize(@non_oclc_non_bib, prefix: true))
     end
   end
 


### PR DESCRIPTION
Advances pulibrary/orangelight#376. Also logs bibs that aren't properly prefixed in the 776w/787w fields.
Updated travis config to use container-based builds.
