### PR TITLE
logging when holdings are missing, access facet stored field

### DIFF
--- a/lib/traject_config.rb
+++ b/lib/traject_config.rb
@@ -842,7 +842,11 @@ to_field 'subject_era_facet', marc_era_facet
 
 to_field 'holdings_1display' do |record, accumulator|
   all_holdings = process_holdings(record)
-  accumulator[0] = all_holdings.to_json.to_s unless all_holdings == {}
+  if all_holdings == {}
+    logger.error "#{record['001']} - Missing holdings"
+  else
+    accumulator[0] = all_holdings.to_json.to_s
+  end
 end
 
 to_field 'location_display', extract_marc('852b', :allow_duplicates => true) do |record, accumulator|
@@ -858,7 +862,7 @@ to_field 'location', extract_marc('852b', :allow_duplicates => true) do |record,
 end
 # # #    1000
 
-to_field 'access_facet', extract_marc('852b', :allow_duplicates => true) do |record, accumulator|
+to_field 'access_s', extract_marc('852b', :allow_duplicates => true) do |record, accumulator|
   accumulator = Traject::TranslationMap.new("access", :default => "In the Library").translate_array!(accumulator)
 end
 

--- a/spec/lib/config_spec.rb
+++ b/spec/lib/config_spec.rb
@@ -69,22 +69,22 @@ describe 'From traject_config.rb' do
       rel_names['Related name'].each {|n| expect(@related_names['author_s']).to include(n)}
     end
   end
-  describe 'access_facet' do
+  describe 'access_s' do
     it 'value is in the library for all non-online holding locations' do
       expect(@sample3['location_code_s'][0]).to eq 'scidoc' # Lewis Library
-      expect(@sample3['access_facet']).to include 'In the Library'
-      expect(@sample3['access_facet']).not_to include 'Online'
+      expect(@sample3['access_s']).to include 'In the Library'
+      expect(@sample3['access_s']).not_to include 'Online'
     end
     it 'value is online for elf holding locations' do
       expect(@online['location_code_s'][0]).to eq 'elf1'
-      expect(@online['access_facet']).to include 'Online'
-      expect(@online['access_facet']).not_to include 'In the Library'
+      expect(@online['access_s']).to include 'Online'
+      expect(@online['access_s']).not_to include 'In the Library'
     end
     it 'value can be both in the library and online when there are multiple holdings' do
       expect(@online_at_library['location_code_s']).to include 'elf1'
       expect(@online_at_library['location_code_s']).to include 'rcpph'
-      expect(@online_at_library['access_facet']).to include 'Online'
-      expect(@online_at_library['access_facet']).to include 'In the Library'
+      expect(@online_at_library['access_s']).to include 'Online'
+      expect(@online_at_library['access_s']).to include 'In the Library'
     end
   end
   describe 'holdings_1display' do


### PR DESCRIPTION
- Making the access facet a stored field will allow Blacklight to determine whether it should render online access holding info, even if the links (856s) are missing.
- Log when records don't have any mfhds.
