### PR TITLE
only accept first 852b, allow multiple holding block info values

### DIFF
--- a/lib/princeton_marc.rb
+++ b/lib/princeton_marc.rb
@@ -415,9 +415,9 @@ def process_holdings record
       if s_field.code == '0'
         holding_id = s_field.value
       elsif s_field.code == 'b'
-        holding['location'] = Traject::TranslationMap.new("locations", :default => "__passthrough__")[s_field.value]
-        holding['library'] = Traject::TranslationMap.new("location_display", :default => "__passthrough__")[s_field.value]
-        holding['location_code'] = s_field.value
+        holding['location'] ||= Traject::TranslationMap.new("locations", :default => "__passthrough__")[s_field.value]
+        holding['library'] ||= Traject::TranslationMap.new("location_display", :default => "__passthrough__")[s_field.value]
+        holding['location_code'] ||= s_field.value
       elsif /[ckhij]/.match(s_field.code)
         holding['call_number'] ||= []
         holding['call_number'] << s_field.value
@@ -426,9 +426,11 @@ def process_holdings record
           holding['call_number_browse'] << s_field.value
         end
       elsif s_field.code == 'l'
-        holding['shelving_title'] = s_field.value
+        holding['shelving_title'] ||= []
+        holding['shelving_title'] << s_field.value
       elsif s_field.code == 'z'
-        holding['location_note'] = s_field.value
+        holding['location_note'] ||= []
+        holding['location_note'] << s_field.value
       end
     end
     holding['call_number'] = holding['call_number'].join(' ') if holding['call_number']
@@ -447,7 +449,10 @@ def process_holdings record
         value << s_field.value
       end
     end
-    all_holdings[holding_id]['location_has'] = value.join(' ') if (all_holdings[holding_id] and !value.empty?)
+    if (all_holdings[holding_id] and !value.empty?)
+      all_holdings[holding_id]['location_has'] ||= []
+      all_holdings[holding_id]['location_has'] << value.join(' ')
+    end
   end
   Traject::MarcExtractor.cached('866|  |0az').collect_matching_lines(record) do |field, spec, extractor|
     value = []
@@ -461,7 +466,10 @@ def process_holdings record
         value << s_field.value
       end
     end
-    all_holdings[holding_id]['location_has_current'] = value.join(' ') if (all_holdings[holding_id] and !value.empty?)
+    if (all_holdings[holding_id] and !value.empty?)
+      all_holdings[holding_id]['location_has_current'] ||= []
+      all_holdings[holding_id]['location_has_current'] << value.join(' ')
+    end
   end
   Traject::MarcExtractor.cached('8670az').collect_matching_lines(record) do |field, spec, extractor|
     value = []
@@ -475,7 +483,10 @@ def process_holdings record
         value << s_field.value
       end
     end
-    all_holdings[holding_id]['supplements'] = value.join(' ') if (all_holdings[holding_id] and !value.empty?)
+    if (all_holdings[holding_id] and !value.empty?)
+      all_holdings[holding_id]['supplements'] ||= []
+      all_holdings[holding_id]['supplements'] << value.join(' ')
+    end
   end
   Traject::MarcExtractor.cached('8680az').collect_matching_lines(record) do |field, spec, extractor|
     value = []
@@ -489,7 +500,10 @@ def process_holdings record
         value << s_field.value
       end
     end
-    all_holdings[holding_id]['indexes'] = value.join(' ') if (all_holdings[holding_id] and !value.empty?)
+    if (all_holdings[holding_id] and !value.empty?)
+      all_holdings[holding_id]['indexes'] ||= []
+      all_holdings[holding_id]['indexes'] << value.join(' ')
+    end
   end
   all_holdings
 end

--- a/spec/fixtures/sample27.mrx
+++ b/spec/fixtures/sample27.mrx
@@ -73,6 +73,7 @@
       <subfield code="c">Oversize</subfield>
       <subfield code="h">2006-0102E</subfield>
       <subfield code="x">Former call number: Adler Ref 2503</subfield>
+      <subfield code="b">elf</subfield>
     </datafield>
   </record>
 </collection>

--- a/spec/lib/princeton_marc_spec.rb
+++ b/spec/lib/princeton_marc_spec.rb
@@ -344,16 +344,22 @@ describe 'From princeton_marc.rb' do
       @oversize_mfhd_id = "3723853"
       @other_mfhd_id = "4191919"
       @call_number = "M23.L5S6 1973q"
+      @include_loc = "f"
       @f_852 = {"852"=>{"ind1"=>"0","ind2"=>"0","subfields"=>[{"0"=>@oversize_mfhd_id},{"b"=>"anxa"},{"t"=>"2"},{"c"=>"Oversize"},{"h"=>@call_number}]}}
-      @other_852 = {"852"=>{"ind1"=>"0","ind2"=>"0","subfields"=>[{"0"=>@other_mfhd_id},{"b"=>"f"}]}} 
+      @other_852 = {"852"=>{"ind1"=>"0","ind2"=>"0","subfields"=>[{"0"=>@other_mfhd_id},{"b"=>@include_loc},{"b"=>"elf1"}]}}
       @l_866 = {"866"=>{"ind1"=>"3","ind2"=>"1","subfields"=>[{"0"=>@oversize_mfhd_id},{"a"=>"volume 1"},{"z"=>"full"}]}}
+      @l_866_2nd = {"866"=>{"ind1"=>"3","ind2"=>"1","subfields"=>[{"0"=>@oversize_mfhd_id},{"a"=>"In reading room"}]}}
       @c_866 = {"866"=>{"ind1"=>" ","ind2"=>" ","subfields"=>[{"0"=>@oversize_mfhd_id},{"a"=>"v2"},{"z"=>"available"}]}}
       @s_867 = {"867"=>{"ind1"=>"9","ind2"=>" ","subfields"=>[{"0"=>@other_mfhd_id},{"a"=>"v454"}]}}
       @i_868 = {"868"=>{"ind1"=>" ","ind2"=>"0","subfields"=>[{"0"=>@oversize_mfhd_id},{"z"=>"lost"}]}}
       @other_866 = {"866"=>{"ind1"=>" ","ind2"=>" ","subfields"=>[{"0"=>@other_mfhd_id},{"a"=>"v4"},{"z"=>"p3"}]}}
-      @sample_marc = MARC::Record.new_from_hash({ 'fields' => [@f_852, @l_866, @c_866, @s_867, @i_868, @other_866, @other_852] })
+      @sample_marc = MARC::Record.new_from_hash({ 'fields' => [@f_852, @l_866, @l_866_2nd, @c_866, @s_867, @i_868, @other_866, @other_852] })
 
       @holding_block = process_holdings(@sample_marc)
+    end
+
+    it 'includes only first location code in 852 $b' do
+      expect(@holding_block[@other_mfhd_id]['location_code']).to eq(@include_loc)
     end
 
     it 'excludes $c for call_number_browse key' do
@@ -366,17 +372,17 @@ describe 'From princeton_marc.rb' do
     end
 
     it 'location_has takes from 866 $a and $z when the 1st ind is blank or 3-5 and 2nd ind is 0-2' do
-      expect(@holding_block[@oversize_mfhd_id]['location_has']).to eq("volume 1 full")
+      expect(@holding_block[@oversize_mfhd_id]['location_has']).to include("volume 1 full", "In reading room")
     end
-    it 'location_has takes from 866 $a and $z when both indicators are blank' do
-      expect(@holding_block[@oversize_mfhd_id]['location_has_current']).to eq("v2 available")
-      expect(@holding_block[@other_mfhd_id]['location_has_current']).to eq("v4 p3")
+    it 'location_has_current takes from 866 $a and $z when both indicators are blank' do
+      expect(@holding_block[@oversize_mfhd_id]['location_has_current']).to include("v2 available")
+      expect(@holding_block[@other_mfhd_id]['location_has_current']).to include("v4 p3")
     end
     it 'supplements takes from 867 $a and $z' do
-      expect(@holding_block[@other_mfhd_id]['supplements']).to eq("v454")
+      expect(@holding_block[@other_mfhd_id]['supplements']).to include("v454")
     end
     it 'indexes takes from 868 $a and $z' do
-      expect(@holding_block[@oversize_mfhd_id]['indexes']).to eq("lost")
+      expect(@holding_block[@oversize_mfhd_id]['indexes']).to include("lost")
     end
   end
 end


### PR DESCRIPTION
- holding block keys such as 'location_has', 'location_note', etc. can now be multivalued.
- only take the first location code from 852 b and log whenever there are multiple b's present.
- Refactor the location code base records so the 852 field is parsed less often.
